### PR TITLE
don't throw an error if no collective attached to a membership

### DIFF
--- a/src/components/Membership.js
+++ b/src/components/Membership.js
@@ -17,6 +17,11 @@ class Membership extends React.Component {
     const { membership } = this.props;
     const { collective } = membership;
 
+    if (!collective) {
+      console.error(">>> no collective attached to this membership:", membership);
+      return <div />;
+    }
+
     const name = ((collective.name && collective.name.match(/^null/)) ? null : collective.name) || collective.slug;
 
     if (!name) return (<div/>);


### PR DESCRIPTION
fixes opencollective/opencollective#551