### PR TITLE
Don't return blank if collective.name is ""

### DIFF
--- a/src/components/EditCollective.js
+++ b/src/components/EditCollective.js
@@ -136,7 +136,7 @@ class EditCollective extends React.Component {
 
     const collective = this.props.collective || {};
 
-    if (!collective.name) return (<div />);
+    if (!collective.slug) return (<div />);
 
     const { LoggedInUser } = this.props;
 


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/742