### PR TITLE
CSV with all transactions of a collective between a date range

### DIFF
--- a/src/components/Collective.js
+++ b/src/components/Collective.js
@@ -380,6 +380,7 @@ class Collective extends React.Component {
                       collective={this.collective}
                       LoggedInUser={LoggedInUser}
                       limit={5}
+                      showCSVlink={false}
                       />
                       <div className="actions">
                       <Button className="ViewAllTransactionsBtn" bsStyle="default" onClick={() => Router.pushRoute(`/${this.collective.slug}/transactions`)}><FormattedMessage id="transactions.viewAll" defaultMessage="View All Transactions" /></Button>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -118,7 +118,7 @@ class Header extends React.Component {
       }
 
       h1, h2, h3, h4 {
-        font-family: 'montserratlight';
+        font-family: 'lato','montserratlight';
       }
 
       h1 {

--- a/src/components/InputField.js
+++ b/src/components/InputField.js
@@ -164,6 +164,8 @@ class InputField extends React.Component {
       case 'date':
       case 'datetime':
         const timeFormat = field.type === 'date' ? false : true;
+        const { closeOnSelect } = this.props;
+
         this.input = (
         <FormGroup>
           {field.className === 'horizontal' &&
@@ -178,7 +180,8 @@ class InputField extends React.Component {
                   value={moment.tz(new Date(this.state.value || field.defaultValue), context.timezone)}
                   isValidDate={field.validate}
                   onChange={date => date.toISOString ? this.handleChange(date.toISOString()) : false}
-                  />
+                  closeOnSelect={closeOnSelect}
+                />
               </Col>
             </div>
           }
@@ -191,7 +194,8 @@ class InputField extends React.Component {
                 value={moment.tz(new Date(this.state.value || field.defaultValue), context.timezone)}
                 isValidDate={field.validate}
                 onChange={date => date.toISOString ? this.handleChange(date.toISOString()) : false}
-                />
+                closeOnSelect={closeOnSelect}
+              />
               {field.description && <HelpBlock>{field.description}</HelpBlock>}
             </div>
           }

--- a/src/components/Transactions.js
+++ b/src/components/Transactions.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Transaction from './Transaction';
 import { ButtonGroup, Button } from 'react-bootstrap';
 import { FormattedMessage } from 'react-intl';
+
 import colors from '../constants/colors';
+import Transaction from './Transaction';
+import TransactionsExportPopoverAndButton from './TransactionsExportPopoverAndButton';
 
 class Transactions extends React.Component {
 
@@ -38,7 +40,7 @@ class Transactions extends React.Component {
   }
 
   render() {
-    const { collective, transactions, LoggedInUser } = this.props;
+    const { collective, transactions, LoggedInUser, showCSVlink } = this.props;
 
     if (!transactions) {
       return (<div />);
@@ -94,6 +96,8 @@ class Transactions extends React.Component {
           }
         `}</style>
 
+        {showCSVlink && <TransactionsExportPopoverAndButton collective={collective} />}
+
         <div className="filter">
           <ButtonGroup className="filterBtnGroup">
             <Button className="filterBtn all" bsSize="small" bsStyle={!this.state.type ? 'primary' : 'default'} onClick={() => this.refetch()}>
@@ -120,7 +124,7 @@ class Transactions extends React.Component {
               collective={collective}
               transaction={transaction}
               LoggedInUser={LoggedInUser}
-              />
+            />
           )}
           { transactions.length === 0 &&
             <div className="empty">

--- a/src/components/TransactionsExportPopoverAndButton.js
+++ b/src/components/TransactionsExportPopoverAndButton.js
@@ -1,0 +1,179 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import { withApollo } from 'react-apollo';
+import { FormattedMessage } from 'react-intl';
+import {
+  Button,
+  Popover,
+  OverlayTrigger,
+} from 'react-bootstrap';
+
+import { json2csv, exportFile } from '../lib/export_file';
+import withIntl from '../lib/withIntl';
+import InputField from './InputField';
+import { getTransactionsQuery } from './TransactionsWithData';
+
+/* Convert the output of the allTransactions query into a CSV payload
+   that can be downloaded directly by the user */
+const transformResultInCSV = (json) => {
+  const q = (value) => `"${value}"`              /* Quote value */
+  const f = (value) => (value / 100).toFixed(2); /* Add cents */
+  const d = (value) => moment(new Date(value)).format("YYYY-MM-DD HH:mm:ss");
+
+  // Sanity check. It will return an empty CSV for the user
+  if (json.length === 0) return '';
+
+  // All the json lines contain the same values for these two
+  // variables. It's save to get them from any index.
+  const hostCurrency = json[0].host.currency;
+  const collectiveCurrency = json[0].host.currency;
+
+  const header = [
+    "Transaction Description",
+    "User Name",
+    "User Profile",
+    "Transaction Date",
+    "Collective Currency",
+    "Host Currency",
+    "Transaction Amount",
+    `Host Fee (${hostCurrency})`,
+    `OpenCollective Fee (${hostCurrency})`,
+    `Payment Processor Fee (${hostCurrency})`,
+    `Net Amount (${collectiveCurrency})`,
+  ].map((i) => q(i)).join(',');
+
+  const lines = json.map((i) => {
+    const profile = `http://opencollective.com/${i.fromCollective.slug}`;
+    return [
+      q(i.description),                       /* Transaction Description */
+      q(i.fromCollective.name),               /* User Name  */
+      q(profile),                             /* User Profile  */
+      d(i.createdAt),                         /* Transaction Date  */
+      q(i.currency),                          /* Currency */
+      f(i.amount),                            /* Transaction Amount */
+      f(i.hostFeeInHostCurrency),             /* Host Fee */
+      f(i.platformFeeInHostCurrency),         /* Platform Fee */
+      f(i.paymentProcessorFeeInHostCurrency), /* Payment Processor Fee */
+      f(i.netAmountInCollectiveCurrency),     /* Net Amount */
+    ].join(',');
+  });
+
+  return [header].concat(lines).join('\n');
+}
+
+class ExportForm extends React.Component {
+
+  static propTypes = {
+    collective: PropTypes.object,
+  }
+
+  constructor(props) {
+    super(props);
+
+    // Calculate the start: first day of previous month & end date: today.
+    const oneMonthAgo = moment().subtract(1, 'months')._d;
+    const defaultStartDate = new Date(oneMonthAgo.getFullYear(), oneMonthAgo.getMonth(), 1);
+    const defaultEndDate = new Date;
+
+    this.state = {
+      dateFrom: defaultStartDate,
+      dateTo: defaultEndDate,
+      data: [],
+      downloadBtnDisabled: false,
+      searchReturnedEmpty: false,
+    };
+  }
+
+  async download() {
+    const result = await this.props.client.query({
+      query: getTransactionsQuery,
+      variables: {
+        CollectiveId: this.props.collective.id,
+        dateFrom: this.state.dateFrom,
+        dateTo: this.state.dateTo,
+      },
+    });
+    const csv = transformResultInCSV(result.data.allTransactions);
+
+    // Don't prompt the file download unless there's data coming
+    if (csv === '') {
+      this.setState({ searchReturnedEmpty: true });
+      return;
+    }
+
+    // Helper to prepare date values to be part of the file name
+    const format = (d) => moment(d).format('YYYYMMDDHHMMSS');
+    let fileName = `${this.props.collective.slug}--`
+    fileName += `${format(this.state.dateFrom)}-`
+    fileName += `${format(this.state.dateTo)}.csv`;
+    return exportFile('text/plain;charset=utf-8', fileName, csv);
+  }
+
+  updateSearchProps(entries) {
+    this.setState(entries);
+    this.setState({
+      downloadBtnDisabled: !(this.state.dateFrom && this.state.dateTo)
+    });
+  }
+
+  render() {
+    return (
+      <Popover id="csv-date-range" title="Download CSV file" {...this.props}>
+        <style jsx global>{`
+        .control-label {
+          font-weight: 100;
+          font-size: 14px;
+        }
+        .empty-search-error {
+          padding-top: 10px;
+          color: #e21a60;
+        }
+        `}</style>
+        <InputField
+          name="dateFrom"
+          label="Start date"
+          type="date"
+          closeOnSelect
+          defaultValue={this.state.dateFrom}
+          onChange={(dateFrom) => this.updateSearchProps({ dateFrom })} />
+        <InputField
+          name="dateTo"
+          label="End date"
+          type="date"
+          defaultValue={this.state.dateTo}
+          closeOnSelect
+          onChange={(dateTo) => this.updateSearchProps({ dateTo })} />
+        <Button
+          disabled={this.state.disabled}
+          bsSize="small"
+          bsStyle="primary"
+          onClick={this.download.bind(this)}>Download</Button>
+        {this.state.searchReturnedEmpty &&
+         <div className="empty-search-error">
+           <FormattedMessage
+             id='transactions.emptysearch'
+             defaultMessage='There are no transactions in this date range.' />
+         </div>}
+      </Popover>
+    )
+  }
+}
+
+const ExportFormWithClient = withApollo(ExportForm);
+
+class PopoverButton extends React.Component {
+  render() {
+    const form = <ExportFormWithClient collective={this.props.collective} />;
+    return (
+      <OverlayTrigger trigger="click" placement="bottom" overlay={form} rootClose>
+        <a role="button" style={{ float: 'right', fontSize: '12px', padding: 7 }}>
+          <img src="/static/images/icons/download.svg" style={{ paddingRight: 5 }} />
+          <FormattedMessage id='transactions.downloadcsvbutton' defaultMessage='Download CSV' />
+        </a>
+      </OverlayTrigger>
+    )
+  }
+}
+
+export default withIntl(PopoverButton);

--- a/src/components/TransactionsWithData.js
+++ b/src/components/TransactionsWithData.js
@@ -19,7 +19,7 @@ class TransactionsPage extends React.Component {
   }
 
   render() {
-    const { data, LoggedInUser, collective, fetchMore } = this.props;
+    const { data, LoggedInUser, collective, fetchMore, showCSVlink } = this.props;
 
     if (data.error) {
       console.error("graphql error>>>", data.error.message);
@@ -37,6 +37,7 @@ class TransactionsPage extends React.Component {
           refetch={data.refetch}
           fetchMore={fetchMore}
           LoggedInUser={LoggedInUser}
+          showCSVlink={showCSVlink}
           />
 
       </div>
@@ -46,9 +47,9 @@ class TransactionsPage extends React.Component {
 }
 
 
-const getTransactionsQuery = gql`
-query Transactions($CollectiveId: Int!, $type: String, $limit: Int, $offset: Int) {
-  allTransactions(CollectiveId: $CollectiveId, type: $type, limit: $limit, offset: $offset) {
+export const getTransactionsQuery = gql`
+query Transactions($CollectiveId: Int!, $type: String, $limit: Int, $offset: Int, $dateFrom: String, $dateTo: String) {
+  allTransactions(CollectiveId: $CollectiveId, type: $type, limit: $limit, offset: $offset, dateFrom: $dateFrom, dateTo: $dateTo) {
     id
     uuid
     description
@@ -72,6 +73,7 @@ query Transactions($CollectiveId: Int!, $type: String, $limit: Int, $offset: Int
     host {
       id
       name
+      currency
     }
     ... on Expense {
       category

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -54,6 +54,8 @@
   "expenses.submit": "Submit an Expense",
   "collective.transactions.title": "{n, plural, one {Latest transaction} other {Latest transactions}}",
   "transactions.viewAll": "View All Transactions",
+  "transactions.emptysearch": "There are no transactions in this date range.",
+  "transactions.downloadcsvbutton": "Download CSV",
   "membership.role.host": "host",
   "roles.admin.label": "Core Contributor",
   "roles.member.label": "Contributor",

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -35,7 +35,7 @@ export default class IntlDocument extends Document {
       <html>
         <style jsx global>{`
           @font-face {
-            font-family: 'montserratlight';
+            font-family: 'lato','montserratlight';
             src: url('/static/fonts/montserrat/montserrat-light-webfont.eot');
             src: url('/static/fonts/montserrat/montserrat-light-webfont.eot?#iefix') format('embedded-opentype'),
               url('/static/fonts/montserrat/montserrat-light-webfont.woff2') format('woff2'),

--- a/src/pages/transactions.js
+++ b/src/pages/transactions.js
@@ -69,6 +69,7 @@ class TransactionsPage extends React.Component {
             <TransactionsWithData
               collective={collective}
               LoggedInUser={this.state.LoggedInUser}
+              showCSVlink={true}
               />
 
           </div>

--- a/src/static/images/icons/download.svg
+++ b/src/static/images/icons/download.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="10px" height="13px" viewBox="0 0 10 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>icon (download)</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Collective-Page-›-Generic-›-Budget-(USER)" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(-1050.000000, -694.000000)">
+        <g id="TRANSACTIONS" transform="translate(0.000000, 556.000000)" fill="#AAAEB3" fill-rule="nonzero">
+            <g id="::-header">
+                <g id="::-admin-actions" transform="translate(1043.000000, 128.000000)">
+                    <g id="::-button-(download-csv)" transform="translate(0.000000, 4.000000)">
+                        <path d="M17,10.4257703 L14.1428571,10.4257703 L14.1428571,6.19047619 L9.85714286,6.19047619 L9.85714286,10.4257703 L7,10.4257703 L12,15.3669468 L17,10.4257703 Z M7,16.7787115 L7,18.1904762 L17,18.1904762 L17,16.7787115 L7,16.7787115 Z" id="icon-(download)"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
CSV with all transactions of a collective between a date range
    
A button was added to the `:collectiveSlug/transactions` page with a
popover that asks the user for a date range and allows the user to
download a CSV file. This change is related to the following ticket:

https://github.com/opencollective/opencollective/issues/794

The columns in the CSV need some work still