### PR TITLE
Deploy should force push to staging

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "build:server": "./node_modules/.bin/babel -D ./src -d ./build --ignore widget.js && cp src/templates/widget.js build/templates/",
     "build:langs": "./node_modules/.bin/babel src > /dev/null && ./node_modules/.bin/babel-node scripts/translate.js",
     "deploy:production": "git push production master",
-    "deploy:staging": "git push staging master && heroku ps:scale web=1 -a opencollective-staging-api && heroku ps:scale web=1 -a oc-staging-frontend && heroku ps:scale web=1 -a opencollective-staging-website",
+    "deploy:staging": "git push -f staging master && heroku ps:scale web=1 -a opencollective-staging-api && heroku ps:scale web=1 -a oc-staging-frontend && heroku ps:scale web=1 -a opencollective-staging-website",
     "stop:staging": "heroku ps:scale web=0 -a oc-staging-frontend && heroku ps:scale web=0 -a opencollective-staging-website && heroku ps:scale web=0 -a opencollective-staging-api",
     "git:clean": "./scripts/git_clean.sh",
     "postinstall": "npm run build"


### PR DESCRIPTION
The deployment wasn't going through because I didn't have a fast forward push from master to staging and @asood123 suggested changing the `package.json` script to `push -f` to staging.

