### PR TITLE
Request new token from API right after login

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -94,6 +94,15 @@ export function signin(user, redirect) {
   .then(checkResponseStatus);
 }
 
+export async function refreshToken(currentToken) {
+  const response = await fetch('/api/users/update-token', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${currentToken}` }
+  });
+  const json = await response.json();
+  return json.token;
+}
+
 export function get(path, options) {
   if (path.substr(0,1) !== '/') throw new Error("Can only get resources with a relative path");
 

--- a/src/pages/signin.js
+++ b/src/pages/signin.js
@@ -8,6 +8,7 @@ import SignInForm from '../components/SignInForm';
 import withIntl from '../lib/withIntl';
 import { isValidUrl } from '../lib/utils';
 import { FormattedMessage } from 'react-intl';
+import * as api from '../lib/api';
 
 class LoginPage extends React.Component {
 
@@ -17,9 +18,12 @@ class LoginPage extends React.Component {
 
   componentDidMount() {
     if (this.props.token) {
-      window.localStorage.setItem('accessToken', this.props.token);
-      const redirect = (this.props.next || '/');
-      window.location.replace(redirect);
+      api.refreshToken(this.props.token).then((newToken) => {
+        window.localStorage.setItem('accessToken', newToken);
+        window.location.replace(this.props.next || '/');
+      }).catch((error) => {
+        console.log(error);
+      });
     }
   }
 


### PR DESCRIPTION
The token received upon login will now expire in 24h. This change makes
the frontend request a token that will last 30 days right after
receiving the short lived one.