### PR TITLE
lib.api.refreshToken: Don't try to parse json if response isn't 200

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -115,8 +115,11 @@ export async function refreshToken(currentToken) {
     method: 'POST',
     headers: { Authorization: `Bearer ${currentToken}` }
   });
-  const json = await response.json();
-  return json;
+  try {
+    return await response.json();
+  } catch (error) {
+    return { error: response.statusText };
+  }
 }
 
 export function get(path, options) {

--- a/src/pages/signin.js
+++ b/src/pages/signin.js
@@ -23,6 +23,7 @@ class LoginPage extends React.Component {
       const { error, token } = await api.refreshToken(this.props.token);
       if (error) {
         this.setState({ error });
+        console.log(error);
       } else {
         window.localStorage.setItem('accessToken', token);
         window.location.replace(this.props.next || '/');


### PR DESCRIPTION
This doesn't really fix any bugs but there seems to be a case where an API end-point is returning non JSON output which breaks the UI and makes it hard to debug.