### PR TITLE
Refund transaction improvements

### DIFF
--- a/src/components/OrderForm.js
+++ b/src/components/OrderForm.js
@@ -472,7 +472,7 @@ class OrderForm extends React.Component {
             funding: res.card.funding,
             zip: res.card.address_zip
           },
-          save: creditcard.save
+          save: true
         };
         newState.paymentMethod = paymentMethod;
         this.setState(newState);

--- a/src/components/RefundTransactionBtn.js
+++ b/src/components/RefundTransactionBtn.js
@@ -127,6 +127,9 @@ const refundTransactionQuery = gql`
       id
       refundTransaction {
         ${transactionFields}
+        refundTransaction {
+          ${transactionFields}
+        }
       }
     }
   }
@@ -137,21 +140,20 @@ const addMutation = graphql(refundTransactionQuery, {
     refundTransaction: async (id) => await mutate({
       variables: { id },
       update: (proxy, { data: { refundTransaction }}) => {
+        const variables = {
+          CollectiveId: ownProps.collective.id,
+          limit: 20,
+          offset: 0
+        };
+
         // Retrieve the query from the cache
-        const data = proxy.readQuery({
-          query: getTransactionsQuery,
-          variables: {
-            CollectiveId: ownProps.collective.id,
-            limit: 20,
-            offset: 0
-          }
-        });
+        const data = proxy.readQuery({ query: getTransactionsQuery, variables });
 
         // Insert new transaction at the beginning
         data.allTransactions.unshift(refundTransaction.refundTransaction);
 
         // write data back for the query
-        proxy.writeQuery({ query: getTransactionsQuery, data});
+        proxy.writeQuery({ query: getTransactionsQuery, variables, data });
       }
     })
   })

--- a/src/components/RefundTransactionBtn.js
+++ b/src/components/RefundTransactionBtn.js
@@ -17,20 +17,105 @@ class RefundTransactionBtn extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { hidden: false };
+
+    const canRefund = !props.transaction.refundTransaction;
+    this.state = {
+      showing: {
+        canRefund,
+        refunded: !canRefund,
+        confirmRefund: false,
+        refunding: false,
+      }
+    };
   }
 
-  async onClick() {
-    this.setState({ hidden: true });
-    await this.props.refundTransaction(this.props.transaction.id);
+  /** Set state received as true and all the other ones to false.
+   *
+   * This function should be called with a single state. An exception
+   * will be thrown if more than one state is passed.
+   */
+  setShowingState({ canRefund, confirmRefund, refunded, refunding }) {
+    if (canRefund && confirmRefund && refunded && refunding) {
+      throw new Error("Can't set more than one state to true");
+    }
+    this.setState({ showing: {
+      canRefund: !!canRefund,
+      confirmRefund: !!confirmRefund,
+      refunded: !!refunded,
+      refunding: !!refunding,
+    }});
+  }
+
+  /** Fires off the actual refund action.
+   *
+   * This function sets the state to `refunding` before calling the
+   * refund graphql mutation and then it sets the state to `refunded`
+   * after it's all done.
+   */
+  async onClickRefund() {
+    this.setShowingState({ refunding: true });
+    try {
+      await this.props.refundTransaction(this.props.transaction.id);
+    } finally {
+      this.setShowingState({ refunded: true });
+    }
   }
 
   render() {
-    return (this.state.hidden) ? <div/> : (
-      <div className="RefundTransactionBtn">
-        <SmallButton className="refund" bsStyle="danger" bsSize="xsmall" onClick={::this.onClick}>
-          <FormattedMessage id="transaction.refund.btn" defaultMessage="refund" />
-        </SmallButton>
+    return (
+      <div>
+        <style jsx>{`
+          .confirmation {
+            border-top: solid 1px #ddd;
+            margin: 10px 0;
+            padding: 10px 0;
+          }
+          .confirmation strong {
+            display: block;
+            padding-bottom: 5px;
+          }
+          .confirmation-buttons {
+            display: flex;
+            flex-direction: row;
+            justify-content: flex-start;
+          }
+          .confirmation-buttons .SmallButton.refund {
+            margin-right: 10px;
+          }
+        `}</style>
+
+        {/* Already refunded so we don't really don't need to show
+            anything */}
+        { this.state.showing.refunded && <div/> }
+
+        {/* User just pressed refunding. Display loading spinner */}
+        { this.state.showing.refunding &&
+          <div className="confirmation"><em>Refunding</em></div> }
+
+        { this.state.showing.canRefund &&
+          <div className="confirmation">
+            <div className="confirmation-buttons">
+              <SmallButton className="refund" bsStyle="danger" bsSize="xsmall"
+                           onClick={() => ::this.setShowingState({ confirmRefund: true })}>
+                <FormattedMessage id="transaction.refund.btn" defaultMessage="refund" />
+              </SmallButton>
+            </div>
+          </div> }
+
+        { this.state.showing.confirmRefund &&
+          <div className="confirmation">
+            <strong>Do you really want to refund this transaction?</strong>
+            <div className="confirmation-buttons">
+              <SmallButton className="refund" bsStyle="danger" bsSize="xsmall"
+                           onClick={::this.onClickRefund}>
+                <FormattedMessage id="transaction.refund.yes.btn" defaultMessage="Yes, refund!" />
+              </SmallButton>
+              <SmallButton className="no" bsStyle="primary" bsSize="xsmall"
+                           onClick={() => ::this.setShowingState({ canRefund: true })}>
+                <FormattedMessage id="transaction.refund.no.btn" defaultMessage="no" />
+              </SmallButton>
+            </div>
+          </div> }
       </div>
     );
   }

--- a/src/components/Transaction.js
+++ b/src/components/Transaction.js
@@ -43,7 +43,7 @@ class Transaction extends React.Component {
     if (!transaction.fromCollective) return (<div />); // This only occurs for host collectives when they add funds
 
     const type = transaction.type.toLowerCase();
-    const messageType = (transaction.RefundTransactionId) ? 'refund' : type;
+    const messageType = (transaction.refundTransaction) ? 'refund' : type;
 
     let title = transaction.description;
     if (type === 'credit' && (!title || !title.match(/Matching/) && title.match(/donation to /i) && !title.match(/Refund/))) {

--- a/src/components/TransactionDetails.js
+++ b/src/components/TransactionDetails.js
@@ -140,13 +140,12 @@ class TransactionDetails extends React.Component {
           </div>
         }
         <div className="actions">
-          { (LoggedInUser && LoggedInUser.isRoot() && !transaction.refundTransaction) &&
+          { (LoggedInUser && LoggedInUser.isRoot()) &&
             <div className="transactionActions">
               <RefundTransactionBtn
                 transaction={transaction}
                 collective={collective} />
-            </div>
-          }
+            </div> }
         </div>
 
       </div>

--- a/src/components/TransactionDetails.js
+++ b/src/components/TransactionDetails.js
@@ -140,7 +140,7 @@ class TransactionDetails extends React.Component {
           </div>
         }
         <div className="actions">
-          { (LoggedInUser && LoggedInUser.isRoot() && !transaction.RefundTransactionId) &&
+          { (LoggedInUser && LoggedInUser.isRoot() && !transaction.refundTransaction) &&
             <div className="transactionActions">
               <RefundTransactionBtn
                 transaction={transaction}

--- a/src/components/TransactionsExportPopoverAndButton.js
+++ b/src/components/TransactionsExportPopoverAndButton.js
@@ -12,7 +12,7 @@ import {
 import { json2csv, exportFile } from '../lib/export_file';
 import withIntl from '../lib/withIntl';
 import InputField from './InputField';
-import { getTransactionsQuery } from './TransactionsWithData';
+import { getTransactionsQuery } from '../graphql/queries';
 
 /* Convert the output of the allTransactions query into a CSV payload
    that can be downloaded directly by the user */

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -6,7 +6,6 @@ import storage from '../lib/storage';
 
 export const transactionFields = `
   id
-  RefundTransactionId
   uuid
   description
   createdAt
@@ -46,6 +45,9 @@ export const getTransactionsQuery = gql`
 query Transactions($CollectiveId: Int!, $type: String, $limit: Int, $offset: Int, $dateFrom: String, $dateTo: String) {
   allTransactions(CollectiveId: $CollectiveId, type: $type, limit: $limit, offset: $offset, dateFrom: $dateFrom, dateTo: $dateTo) {
     ${transactionFields}
+    refundTransaction {
+      ${transactionFields}
+    }
   }
 }
 `;


### PR DESCRIPTION
This is a follow up of the ticket https://github.com/opencollective/frontend/pull/278. This PR introduces the following improvements:

 * Don't use RefundTransactionId
 * Add confirmation before actually refunding a transaction
 * Properly update the list of transactions after a refund
 * Always save credit card in the donations page (sorta unrelated)