### PR TITLE
Load raf/polyfill when running jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "image-webpack-loader": "3.2.0",
     "jest": "21.2.1",
     "jest-cli": "21.2.1",
+    "raf": "^3.4.0",
     "react-test-renderer": "16.2.0",
     "regenerator-runtime": "0.11.0",
     "sinon": "2.4.1"
@@ -148,6 +149,7 @@
       "\\.(css|less)$": "<rootDir>/test/mocks/styleMock.js"
     },
     "setupFiles": [
+      "raf/polyfill",
       "<rootDir>/test/setup.js"
     ]
   }


### PR DESCRIPTION
Fix warning.

```
 Warning: React depends on requestAnimationFrame. Make sure that you load a polyfill in older browsers. http://fb.me/react-polyfills
```