### PR TITLE
Prefer https for organization URL

### DIFF
--- a/src/components/OrderForm.js
+++ b/src/components/OrderForm.js
@@ -761,7 +761,7 @@ class OrderForm extends React.Component {
                   className="horizontal"
                   type="text"
                   name="organization_website"
-                  pre="http://"
+                  pre="https://"
                   label={intl.formatMessage(this.messages['order.organization.website'])}
                   onChange={(value) => this.handleChange("fromCollective", "website", value)}
                   />


### PR DESCRIPTION
HTTP is deprecated, most sites are HTTPS now so it makes more sense to display this.

Both my collective ( https://opencollective.com/the-london-django-meetup-group ) and our first sponsor ( https://www.thread.com/ ) are HTTPS only. cc @danpalmer