### PR TITLE
Refactor getLoggedInUser

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -11,7 +11,7 @@ const logo = '/static/images/opencollective-icon.svg';
 class TopBar extends React.Component {
 
   static propTypes = {
-    LoggedInUser: PropTypes.object.isRequired,
+    LoggedInUser: PropTypes.object,
     showSearch: PropTypes.bool,
   }
 

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -708,7 +708,8 @@ export const addSubscriptionsData = graphql(getSubscriptionsQuery);
 export const addSearchQueryData = graphql(searchCollectivesQuery);
 
 export const addGetLoggedInUserFunction = component => {
-  const err = new Error('addGetLoggedInUserFunction is deprecated, use withLoggedInUser instead');
-  console.warn(err.message);
+  if (process.env.NODE_ENV == 'development') {
+    console.warn('addGetLoggedInUserFunction is deprecated, use withLoggedInUser instead');
+  }
   return withLoggedInUser(component);
 }

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -1,9 +1,7 @@
 import { graphql } from 'react-apollo'
 import gql from 'graphql-tag'
-import moment from 'moment';
-import LoggedInUser from '../classes/LoggedInUser';
-import storage from '../lib/storage';
-import * as api from '../lib/api';
+
+import withLoggedInUser from '../lib/withLoggedInUser';
 
 export const transactionFields = `
   id
@@ -709,63 +707,8 @@ export const addTiersData = graphql(getTiersQuery);
 export const addSubscriptionsData = graphql(getSubscriptionsQuery);
 export const addSearchQueryData = graphql(searchCollectivesQuery);
 
-const refreshLoggedInUser = async (data) => {
-  let res;
-
-  if (data.LoggedInUser) {
-    const user = new LoggedInUser(data.LoggedInUser);
-    storage.set("LoggedInUser", user, 1000 * 60 * 60);
-    return user;
-  }
-
-  try {
-    res = await data.refetch();
-    if (!res.data || !res.data.LoggedInUser) {
-      storage.set("LoggedInUser", null);
-      return null;
-    }
-    const user = new LoggedInUser(res.data.LoggedInUser);
-    storage.set("LoggedInUser", user, 1000 * 60 * 60);
-    return user;
-  } catch (e) {
-    console.error(">>> getLoggedInUser error:", e);
-    storage.set("LoggedInUser", null);
-    return null;
-  }
-};
-
-const maybeRefreshAccessToken = async (currentToken) => {
-  const { exp } = JSON.parse(atob(currentToken.split('.')[1]));
-  const shouldUpdate = moment(exp * 1000).subtract(1, 'month').isBefore(new Date);
-  if (shouldUpdate) {
-    const { token } = await api.refreshToken(currentToken);
-    window.localStorage.getItem('accessToken', token);
-  }
-};
-
-export const addGetLoggedInUserFunction = (component) => {
-  const accessToken = typeof window !== 'undefined' && window.localStorage.getItem('accessToken');
-  if (!accessToken) return component;
-  return graphql(getLoggedInUserQuery, {
-    props: ({ data }) => ({
-      data,
-      getLoggedInUser: async () => {
-        const token = window.localStorage.getItem('accessToken');
-        if (!token) {
-          storage.set("LoggedInUser", null);
-          return null;
-        }
-
-        // Just issue the request, don't wait for this call
-        maybeRefreshAccessToken(token);
-
-        const cache = storage.get("LoggedInUser");
-        if (cache) {
-          refreshLoggedInUser(data); // we don't wait.
-          return new LoggedInUser(cache);
-        }
-        return await refreshLoggedInUser(data);
-      }
-    })
-  })(component);
+export const addGetLoggedInUserFunction = component => {
+  const err = new Error('addGetLoggedInUserFunction is deprecated, use withLoggedInUser instead');
+  console.warn(err.message);
+  return withLoggedInUser(component);
 }

--- a/src/lib/withLoggedInUser.js
+++ b/src/lib/withLoggedInUser.js
@@ -1,0 +1,82 @@
+import React from 'react'
+import PropTypes from 'prop-types';
+import moment from 'moment';
+
+import * as api from '../lib/api';
+import storage from '../lib/storage';
+import LoggedInUser from '../classes/LoggedInUser';
+import { getLoggedInUserQuery } from '../graphql/queries';
+
+const maybeRefreshAccessToken = async (currentToken) => {
+  const { exp } = JSON.parse(atob(currentToken.split('.')[1]));
+  const shouldUpdate = moment(exp * 1000).subtract(1, 'month').isBefore(new Date);
+  if (shouldUpdate) {
+    const { token } = await api.refreshToken(currentToken);
+    window.localStorage.setItem('accessToken', token);
+  }
+};
+
+export default WrappedComponent => {
+
+  return class withLoggedInUser extends React.Component {
+
+    static propTypes = {
+      client: PropTypes.object
+    }
+
+    static getInitialProps (props) {
+      return WrappedComponent.getInitialProps(props);
+    }
+
+    getLoggedInUser = async () => {
+      // only Client Side for now
+      if (!process.browser || !window) {
+        return null;
+      }
+
+      // If no localStorage token, reset LoggedInUser
+      const token = window.localStorage.getItem('accessToken');
+      if (!token) {
+        storage.set("LoggedInUser", null);
+        return null;
+      }
+
+      // refresh Access Token in the background if needed
+      maybeRefreshAccessToken(token);
+
+      // From cache
+      const cache = storage.get("LoggedInUser");
+      if (cache) {
+        return new LoggedInUser(cache);
+      }
+
+      // From GraphQL with Apollo
+      const result = await this.props.client.query({
+        query: getLoggedInUserQuery,
+      });
+
+      // No result
+      if (!result.data || !result.data.LoggedInUser) {
+        storage.set("LoggedInUser", null);
+        return null;
+      }
+
+      // Store in cache
+      storage.set("LoggedInUser", result.data.LoggedInUser, 1000 * 60 * 60);
+
+      // Fresh data from Apollo
+      return new LoggedInUser(result.data.LoggedInUser);
+    }
+
+    render() {
+      return (
+        <WrappedComponent
+          getLoggedInUser={this.getLoggedInUser}
+          {...this.props}
+          />
+      );
+    }
+
+  }
+
+}

--- a/src/pages/collective.js
+++ b/src/pages/collective.js
@@ -1,8 +1,9 @@
-import withData from '../lib/withData'
-import withIntl from '../lib/withIntl';
 import React from 'react'
-import { addCollectiveData, addGetLoggedInUserFunction } from '../graphql/queries';
-
+import PropTypes from 'prop-types';
+import { addCollectiveData } from '../graphql/queries';
+import withData from '../lib/withData';
+import withLoggedInUser from '../lib/withLoggedInUser';
+import withIntl from '../lib/withIntl';
 import NotFound from '../components/NotFoundPage';
 import Loading from '../components/Loading';
 import ErrorPage from '../components/ErrorPage';
@@ -11,13 +12,19 @@ import UserCollective from '../components/UserCollective';
 
 class CollectivePage extends React.Component {
 
-  constructor(props) {
-    super(props);
-    this.state = {};
+  static propTypes = {
+    getLoggedInUser: PropTypes.func.isRequired,
+    data: PropTypes.object,
+    query: PropTypes.object,
   }
 
   static getInitialProps ({ query }) {
     return { slug: query && query.slug, query }
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {};
   }
 
   async componentDidMount() {
@@ -61,4 +68,4 @@ class CollectivePage extends React.Component {
   }
 }
 
-export default withData(addGetLoggedInUserFunction(addCollectiveData(withIntl(CollectivePage))));
+export default withData(withLoggedInUser(addCollectiveData(withIntl(CollectivePage))));


### PR DESCRIPTION
The way we were implementing getLoggedInUser was not optimal.

  - duplicate requests were issued
  - we were still fetching data despite caching

This was mainly because we were using the 'apollo graphql data/query' pattern while not using the data passed as props.

This PR is proposing to use a much more simple pattern for this functionality.
