### PR TITLE
Expense Page: allow pay action to submit

### DIFF
--- a/src/components/ExpenseWithData.js
+++ b/src/components/ExpenseWithData.js
@@ -16,7 +16,10 @@ class ExpenseWithData extends React.Component {
     view: PropTypes.string, // "compact" for homepage (can't edit expense, don't show header), "list" for list view, "details" for details view
     filter: PropTypes.object, // { category, recipient }
     defaultAction: PropTypes.string, // "new" to open the new expense form by default
-    LoggedInUser: PropTypes.object
+    LoggedInUser: PropTypes.object,
+    allowPayAction: PropTypes.bool,
+    lockPayAction: PropTypes.func,
+    unlockPayAction: PropTypes.func,
   }
 
   constructor(props) {
@@ -28,7 +31,10 @@ class ExpenseWithData extends React.Component {
       data,
       LoggedInUser,
       collective,
-      view
+      view,
+      allowPayAction,
+      lockPayAction,
+      unlockPayAction,
     } = this.props;
 
     if (data.error) {
@@ -52,7 +58,10 @@ class ExpenseWithData extends React.Component {
           view={view}
           editable={true}
           LoggedInUser={LoggedInUser}
-          />
+          allowPayAction={allowPayAction}
+          lockPayAction={lockPayAction}
+          unlockPayAction={unlockPayAction}
+        />
 
         { view === 'details' &&
           <CommentsWithData

--- a/src/pages/expense.js
+++ b/src/pages/expense.js
@@ -22,7 +22,9 @@ class ExpensePage extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      isPayActionLocked: false,
+    };
   }
 
   async componentDidMount() {
@@ -110,7 +112,10 @@ class ExpensePage extends React.Component {
                   collective={collective}
                   view="details"
                   LoggedInUser={this.state.LoggedInUser}
-                  />
+                  allowPayAction={!this.state.isPayActionLocked}
+                  lockPayAction={() => this.setState({ isPayActionLocked: true })}
+                  unlockPayAction={() => this.setState({ isPayActionLocked: false })}
+                />
 
               </div>
 


### PR DESCRIPTION
The `ExpenseWithData` component did not allow for submitting expenses, so this PR fixes that issue. 

<img width="899" alt="screen shot 2018-05-08 at 11 52 12 am" src="https://user-images.githubusercontent.com/3051193/39768070-4a05117a-52b6-11e8-9fd4-702b7b519bfa.png">
