### PR TITLE
Queries: include expensePolicy in getCollectiveToEditQuery

### DIFF
--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -152,6 +152,7 @@ const getCollectiveToEditQuery = gql`
       settings
       createdAt
       isHost
+      expensePolicy
       stats {
         id
         yearlyBudget


### PR DESCRIPTION
Fixes opencollective/opencollective#1081