### PR TITLE
CollectivesWithData: use new Enum types in allCollectives query

### DIFF
--- a/src/components/CollectivesWithData.js
+++ b/src/components/CollectivesWithData.js
@@ -124,7 +124,7 @@ class CollectivesWithData extends React.Component {
 }
 
 const getCollectivesQuery = gql`
-query allCollectives($HostCollectiveId: Int, $hostCollectiveSlug: String, $ParentCollectiveId: Int, $tags: [String], $memberOfCollectiveSlug: String, $role: String, $type: String, $limit: Int, $offset: Int, $orderBy: String, $orderDirection: String) {
+query allCollectives($HostCollectiveId: Int, $hostCollectiveSlug: String, $ParentCollectiveId: Int, $tags: [String], $memberOfCollectiveSlug: String, $role: String, $type: TypeOfCollective, $limit: Int, $offset: Int, $orderBy: CollectiveOrderField, $orderDirection: OrderDirection) {
   allCollectives(HostCollectiveId: $HostCollectiveId, hostCollectiveSlug: $hostCollectiveSlug, memberOfCollectiveSlug: $memberOfCollectiveSlug, role: $role, type: $type, ParentCollectiveId: $ParentCollectiveId, tags: $tags, limit: $limit, offset: $offset, orderBy: $orderBy, orderDirection: $orderDirection) {
     id
     type


### PR DESCRIPTION
After updating the `allCollectives` query to use Enum types for some fields, the usage within this repo needed to be updated as well. Reference PR -> https://github.com/opencollective/opencollective-api/pull/1287