### PR TITLE
Search: display Organizations

### DIFF
--- a/src/components/CollectiveCard.js
+++ b/src/components/CollectiveCard.js
@@ -216,7 +216,7 @@ class CollectiveCard extends React.Component {
             <div className="description">{description}</div>
           </div>
           <div className="footer">
-            { collective.stats &&
+            { collective.stats && collective.type === 'COLLECTIVE' &&
               <div className="stats">
                 <div className="backers">
                   <div className="value">{collective.stats.backers.all}</div>
@@ -238,6 +238,28 @@ class CollectiveCard extends React.Component {
                 </div>
               </div>
             }
+            { collective.stats && collective.memberOf && collective.type === 'ORGANIZATION' && (
+              <div className="stats">
+                <div className="backers">
+                  <div className="value">{collective.memberOf.length}</div>
+                  <div className="label">
+                    <FormattedMessage
+                      id="collective.card.memberOf.count"
+                      defaultMessage="{n, plural, one {collective} other {collectives}} backed"
+                      values={{ n: collective.memberOf.length }}
+                      />
+                  </div>
+                </div>
+                <div className="yearlyBudget">
+                  <div className="value">
+                    <Currency value={collective.stats.totalAmountSent} currency={collective.currency} />
+                  </div>
+                  <div className="label">
+                    <FormattedMessage id="collective.card.stats.totalAmountSent" defaultMessage="contributed" />
+                  </div>
+                </div>
+              </div>
+            ) }
             { membership &&
               <div className="membership">
                 <div className="role">{tierName}</div>

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -679,10 +679,14 @@ export const searchCollectivesQuery = gql`
         stats {
           id
           balance
+          totalAmountSent
           yearlyBudget
           backers {
             all
           }
+        }
+        memberOf(role: "BACKER") {
+          id
         }
       }
       limit

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -168,7 +168,7 @@ class SearchPage extends React.Component {
                 <p className="center"><em>No collectives found matching your query: &quot;{term}&quot;</em></p>
               )}
             </Row>
-            {showCollectives && collectives.length !== 0 && <Row>
+            {showCollectives && collectives.length !== 0 && total > limit && <Row>
               <ul className="pagination">
                 { Array(Math.ceil(total / limit)).fill(1).map((n, i) => (
                   <li key={i * limit} className={classNames({ active: (i * limit) === offset })}>


### PR DESCRIPTION
Search currently only indexes collectives but we want to add support for organizations. This PR includes UI and query changes to show relevant organization stats in the search cards. 

Also:

- hides the Pagination if one page of results is returned

Preview:

<img width="1394" alt="screen shot 2018-05-18 at 2 54 56 pm" src="https://user-images.githubusercontent.com/3051193/40253502-0015985a-5aae-11e8-8ae8-be514d5554b0.png">

<img width="245" alt="screen shot 2018-05-18 at 2 55 07 pm" src="https://user-images.githubusercontent.com/3051193/40253512-06ef15c0-5aae-11e8-9ed6-d227f3612eec.png">
