### PR TITLE
Update cypress default timeout to 8000ms

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
   "viewportWidth": 1000,
   "viewportHeight": 1660,
-  "projectId": "yt5kwm"
+  "projectId": "yt5kwm",
+  "defaultCommandTimeout": 8000
 }


### PR DESCRIPTION
tests are failing regularly and this attempt reducing failures