### PR TITLE
better withLoggedInUser

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "image-to-ascii": "3.0.11",
     "intl": "1.2.5",
     "isomorphic-fetch": "2.2.1",
+    "jsonwebtoken": "^8.2.1",
     "lodash": "4.17.10",
     "lru-cache": "4.1.3",
     "markdown-loader": "2.0.2",


### PR DESCRIPTION
- decode jwt token with `jsonwebtoken` library
- refresh in the background LoggedInUser each time it's requested