### PR TITLE
CreateExpenseForm: autofill paypalEmail from LoggedInUser

### DIFF
--- a/src/apps/expenses/components/CreateExpenseForm.js
+++ b/src/apps/expenses/components/CreateExpenseForm.js
@@ -47,7 +47,8 @@ class CreateExpenseForm extends React.Component {
       modified: false,
       expense: {
         category: Object.keys(this.categoriesOptions[0])[0],
-        payoutMethod: 'paypal'
+        payoutMethod: 'paypal',
+        paypalEmail: (props.LoggedInUser && props.LoggedInUser.paypalEmail) || null,
       },
       isExpenseValid: false,
       loading: false


### PR DESCRIPTION
While creating expenses, I noticed how inconvenient it is to enter my paypal email in the expense form when I know it is attached to my profile data. I would like that information to autofill if it is available.

This is a small PR to autofill the paypal email from the LoggedInUser object, otherwise it will default to empty. 

As a followup to this feature, I would also like to add a field somewhere in EditCollectiveForm to allow users to add / edit their paypal email.