### PR TITLE
fix(pages/button): create unique class name to avoid bootstrap clash

### DIFF
--- a/src/pages/button.js
+++ b/src/pages/button.js
@@ -15,54 +15,54 @@ class ButtonPage extends React.Component {
               margin: 0;
             }
 
-            .btn { 
-            width: 300px;
-            height: 50px;
-            overflow: hidden;
-            margin: 0;
+            .collect-btn { 
+              width: 300px;
+              height: 50px;
+              overflow: hidden;
+              margin: 0;
               padding: 0;
               background-repeat: no-repeat;
-                float:left;
+              float:left;
               border: none;
               background-color: transparent;
               cursor: pointer;
             }
 
-            .btn.contribute {
+            .collect-btn.contribute {
               width: 338px;
             }
 
-            .donate.btn.blue {
+            .donate.collect-btn.blue {
               background-image: url(/static/images/buttons/donate-button-blue.svg);
             }
 
-            .donate.btn.white {
+            .donate.collect-btn.white {
               background-image: url(/static/images/buttons/donate-button-white.svg);
             }
 
-            .contribute.btn.blue {
+            .contribute.collect-btn.blue {
               background-image: url(/static/images/buttons/contribute-button-blue.svg);
             }
 
-            .contribute.btn.white {
+            .contribute.collect-btn.white {
               background-image: url(/static/images/buttons/contribute-button-white.svg);
             }
 
-            .btn:hover {
+            .collect-btn:hover {
               background-position: 0 -50px;
             }
-            .btn:active {
+            .collect-btn:active {
               background-position: 0 -100px;
             }
-            .btn:focus {
+            .collect-btn:focus {
               outline: 0;
             }
 
-            .btn.hover {
+            .collect-btn.hover {
               background-position: 0 -100px;
             }
           `}</style>
-        <a type="button" className={`btn ${color} ${verb}`} target="_blank" rel="noopener noreferrer" href={`https://opencollective.com/${collectiveSlug}/${verb}`} />
+        <a type="button" className={`collect-btn ${color} ${verb}`} target="_blank" rel="noopener noreferrer" href={`https://opencollective.com/${collectiveSlug}/${verb}`} />
       </div>
     );
   }


### PR DESCRIPTION
When investigating a recent styling issue with the `:collective/edit` page, I noticed some weird `.btn` inline styles overriding the bootstrap `.btn` styles. 

Reference:

<img width="1389" alt="screen shot 2018-06-11 at 5 50 03 pm" src="https://user-images.githubusercontent.com/3051193/41259063-3bb0d56e-6da0-11e8-9238-fce32a77c1c9.png">

I traced the issue to `src/pages/button.js` for the contribute / donate button widget styles. As a quick fix, I replaced the `.btn` class with something more uniquely scoped to the component, `.collect-btn`. 

This will eventually export a `styled-component` but this should fix the issue in the meantime although I was not able to recreate the issue locally or in staging, which leads me to believe it is some production setting for `styled-jsx`. 