### PR TITLE
EditCollective: allow hosts to add link to terms of service

### DIFF
--- a/src/components/EditCollective.js
+++ b/src/components/EditCollective.js
@@ -122,11 +122,13 @@ class EditCollective extends React.Component {
       ...collective.settings,
       goals: CollectiveInputType.goals,
       editor: CollectiveInputType.markdown ? 'markdown' : 'html',
-      sendInvoiceByEmail: CollectiveInputType.sendInvoiceByEmail
+      sendInvoiceByEmail: CollectiveInputType.sendInvoiceByEmail,
+      tos: CollectiveInputType.tos,
     };
     delete CollectiveInputType.goals;
     delete CollectiveInputType.markdown;
     delete CollectiveInputType.sendInvoiceByEmail;
+    delete CollectiveInputType.tos;
     this.setState( { status: 'loading' });
     try {
       if (CollectiveInputType.backgroundImage === defaultBackgroundImage[CollectiveInputType.type]) {

--- a/src/components/EditCollectiveForm.js
+++ b/src/components/EditCollectiveForm.js
@@ -39,7 +39,7 @@ class EditCollectiveForm extends React.Component {
       members: collective.members || [{}],
       tiers: collective.tiers || [{}],
       goals: collective.settings.goals || [{}],
-      paymentMethods: collective.paymentMethods || [{}]
+      paymentMethods: collective.paymentMethods || [{}],
     };
 
     this.showEditTiers = ['COLLECTIVE', 'EVENT'].includes(collective.type);
@@ -55,6 +55,8 @@ class EditCollectiveForm extends React.Component {
       'type.label': { id: 'collective.type.label', defaultMessage: 'type' },
       'name.label': { id: 'collective.name.label', defaultMessage: 'name' },
       'tags.label': { id: 'collective.tags.label', defaultMessage: 'tags' },
+      'tos.label': { id: 'collecitve.tos.label', defaultMessage: 'Terms of Service' },
+      'tos.description': { id: 'collective.tos.description', defaultMessage: 'Link to the terms by which this host will collect money on behalf of their collectives'},
       'tags.description': { id: 'collective.tags.description', defaultMessage: 'Make your collective discoverable in search and related collectives (comma separated)' },
       'company.label': { id: 'collective.company.label', defaultMessage: 'company' },
       'company.description': { id: 'collective.company.description', defaultMessage: 'Start with a @ to reference an organization (e.g. @airbnb)' },
@@ -184,7 +186,14 @@ class EditCollectiveForm extends React.Component {
           maxLength: 128,
           type: 'text',
           placeholder: 'meetup, javascript'
-        }
+        },
+        {
+          name: 'tos',
+          type: 'text',
+          placeholder: '',
+          defaultValue: get(this.state.collective, 'settings.tos'),
+          when: () => get(this.state.collective, 'isHost'),
+        },
       ],
       images: [
         {


### PR DESCRIPTION
This PR allows hosts to add a link to their terms of service document for collectives to check when applying. 

Edit Collective Preview:
<img width="742" alt="screen shot 2018-06-21 at 12 18 50 pm" src="https://user-images.githubusercontent.com/3051193/41732021-eef11bde-754d-11e8-991d-2feda6aada7e.png">

Create Collective with TOS:
<img width="727" alt="screen shot 2018-06-21 at 12 19 05 pm" src="https://user-images.githubusercontent.com/3051193/41732043-fce2ce18-754d-11e8-8690-54b899b92888.png">

