### PR TITLE
Button Page: use styled-components instead of styled-jsx

### DIFF
--- a/src/pages/button.js
+++ b/src/pages/button.js
@@ -1,4 +1,31 @@
 import React from 'react';
+import styled from 'styled-components';
+
+const CollectButton = styled.a`
+  background-color: transparent;
+  background-image: ${({ color, verb }) => `url(/static/images/buttons/${verb}-button-${color}.svg)`};
+  background-repeat: no-repeat;
+  cursor: pointer;
+  display: block;
+  float: left;
+  height: 50px;
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+  width: ${({ verb }) => verb === 'contribute' ? '338px' : '300px'};
+
+  &:hover {
+    background-position: 0 -50px;
+  }
+
+  &:active {
+    background-position: 0 -100px;
+  }
+
+  &:focus {
+    outline: 0;
+  }
+`;
 
 class ButtonPage extends React.Component {
   static getInitialProps ({ query: { color, collectiveSlug, verb } }) {
@@ -9,61 +36,7 @@ class ButtonPage extends React.Component {
     const { color = 'white', collectiveSlug, verb = 'donate' } = this.props;
 
     return (
-      <div>
-        <style jsx>{`
-            :global(body) {
-              margin: 0;
-            }
-
-            .collect-btn { 
-              width: 300px;
-              height: 50px;
-              overflow: hidden;
-              margin: 0;
-              padding: 0;
-              background-repeat: no-repeat;
-              float:left;
-              border: none;
-              background-color: transparent;
-              cursor: pointer;
-            }
-
-            .collect-btn.contribute {
-              width: 338px;
-            }
-
-            .donate.collect-btn.blue {
-              background-image: url(/static/images/buttons/donate-button-blue.svg);
-            }
-
-            .donate.collect-btn.white {
-              background-image: url(/static/images/buttons/donate-button-white.svg);
-            }
-
-            .contribute.collect-btn.blue {
-              background-image: url(/static/images/buttons/contribute-button-blue.svg);
-            }
-
-            .contribute.collect-btn.white {
-              background-image: url(/static/images/buttons/contribute-button-white.svg);
-            }
-
-            .collect-btn:hover {
-              background-position: 0 -50px;
-            }
-            .collect-btn:active {
-              background-position: 0 -100px;
-            }
-            .collect-btn:focus {
-              outline: 0;
-            }
-
-            .collect-btn.hover {
-              background-position: 0 -100px;
-            }
-          `}</style>
-        <a type="button" className={`collect-btn ${color} ${verb}`} target="_blank" rel="noopener noreferrer" href={`https://opencollective.com/${collectiveSlug}/${verb}`} />
-      </div>
+      <CollectButton type="button" target="_blank" rel="noopener noreferrer" href={`https://opencollective.com/${collectiveSlug}/${verb}`} color={color} verb={verb} />
     );
   }
 }


### PR DESCRIPTION
To fix some weird overrides of the `.btn` class from Donate/Contribute button embedded page, the link/button has been refactored to use `styled-components`. A nice advantage of this pattern means we could easily abstract the button into a separate component file to share around the application. 