### PR TITLE
Home Page: more accurate heading copy for active collectives

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -268,7 +268,7 @@ class HomePage extends React.Component {
 
             <Container py={3}>
               <Flex mb={3} justifyContent="space-between" px={[1, null, 0]}>
-                <H3>Most active</H3>
+                <H3>Active spenders</H3>
                 <StyledLink href="/discover">See all &gt;</StyledLink>
               </Flex>
               <Container display="flex" flexWrap="wrap" justifyContent="space-between">


### PR DESCRIPTION
Changing "Most active" to "Active spenders" as it is more accurate to the query populating those collectives. 