### PR TITLE
show the net amount of a transaction in transaction.currency

### DIFF
--- a/src/apps/expenses/components/TransactionDetails.js
+++ b/src/apps/expenses/components/TransactionDetails.js
@@ -139,7 +139,7 @@ class TransactionDetails extends React.Component {
             <span className="netAmountInCollectiveCurrency">
               <FormattedNumber
                 value={transaction.netAmountInCollectiveCurrency / 100}
-                currency={collective.currency}
+                currency={transaction.currency}
                 {...this.currencyStyle}
                 />
             </span>


### PR DESCRIPTION
instead of collective.currency

Some collectives already had transactions before we changed the currency of the collective.
That's why we shouldn't show the net amount of a transaction with collective.currency but we should use transaction.currency

Eg. https://opencollective.com/techforgoodnz/transactions

