### PR TITLE
createExpense Page: use Flex, Box components for responsive layout

### DIFF
--- a/cypress/integration/21-collective.create.test.js
+++ b/cypress/integration/21-collective.create.test.js
@@ -32,7 +32,6 @@ describe("create a collective on default host", () => {
     cy.get('.error').contains("Please accept the terms of service");
     cy.get('.tos input[type="checkbox"]').click()
     cy.get('.actions button').click();
-    cy.wait(100)
     cy.get('.result').contains("Collective created successfully");
     cy.wait(800);
     cy.get('.CollectivePage .NotificationLine', { timeout: 5000 }).contains("Your collective has been created with success");

--- a/cypress/integration/27-expenses.create.test.js
+++ b/cypress/integration/27-expenses.create.test.js
@@ -59,7 +59,7 @@ describe("new expense", () => {
     cy.get('button[type=submit]').click();
     cy.screenshot("expenseCreatedPaypalLoggedOut");
     cy.get('.expenseCreated').contains('success');
-    cy.get('.actions .viewAllExpenses').click();
+    cy.get('.whiteblue.viewAllExpenses').click();
     cy.wait(300)
     cy.get('.itemsList .expense', { timeout: 10000 })
     cy.get('.Expenses .expense:first .description').contains(expenseDescription)
@@ -97,7 +97,7 @@ describe("new expense", () => {
     cy.get('button[type=submit]').click();
     cy.screenshot("expenseCreatedLoggedIn");
     cy.get('.expenseCreated').contains('success');
-    cy.get('.actions .viewAllExpenses').click();
+    cy.get('.whiteblue.viewAllExpenses').click();
     cy.wait(300)
     cy.get('.itemsList .expense', { timeout: 10000 })
     cy.get('.Expenses .expense:first .description').contains(expenseDescription);

--- a/src/pages/createExpense.js
+++ b/src/pages/createExpense.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { pick } from 'lodash';
-import { FormattedMessage } from 'react-intl'
-import { graphql, compose } from 'react-apollo'
-import gql from 'graphql-tag'
+import { FormattedMessage } from 'react-intl';
+import { graphql, compose } from 'react-apollo';
+import gql from 'graphql-tag';
+import { Box, Flex } from 'grid-styled';
 
 import { addGetLoggedInUserFunction } from '../graphql/queries';
 import withData from '../lib/withData';
@@ -31,7 +32,7 @@ class ExpensesPage extends React.Component {
   constructor(props) {
     super(props);
     this.createExpense = this.createExpense.bind(this);
-    this.state = {};
+    this.state = { expenseCreated: false };
   }
 
   async componentDidMount() {
@@ -78,28 +79,6 @@ class ExpensesPage extends React.Component {
 
     return (
       <div className="ExpensesPage">
-        <style jsx>{`
-          .columns {
-            display: flex;
-          }
-          .rightColumn {
-            width: 300px;
-            margin-left: 5rem;
-          }
-          .rightColumn .viewAllExpenses {
-            margin-top: 5rem;
-          }
-          .largeColumn {
-            width: 100%;
-          }
-          .actions {
-            text-align: center;
-            margin: 2rem;
-          }
-          .actions :global(> button) {
-            margin-right: 1rem;
-          }
-        `}</style>
         <Header
           title={collective.name}
           description={collective.description}
@@ -107,7 +86,7 @@ class ExpensesPage extends React.Component {
           image={collective.image || collective.backgroundImage}
           className={this.state.status}
           LoggedInUser={LoggedInUser}
-          />
+        />
 
         <Body>
 
@@ -118,24 +97,26 @@ class ExpensesPage extends React.Component {
             LoggedInUser={LoggedInUser}
             />
 
-          <div className="content columns" >
+          <Flex flexDirection={['column', null, 'row']}>
 
-            <div className="largeColumn">
+            <Box width={[1, null, 3/4]} >
 
               { expenseCreated &&
-                <div className="expenseCreated">
-                  <p>
+                <Box m={3}>
+                  <p className="expenseCreated">
                     <FormattedMessage id="expense.created" defaultMessage="Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved. Then, the host ({host}) will proceed to reimburse your expense." values={{ host: collective.host.name }} />
                   </p>
-                  <div className="actions">
+                  <Flex justifyContent="center" mt={4} flexWrap="wrap">
                     <Button className="blue" onClick={() => this.setState({ expenseCreated: null, showNewExpenseForm: true })}>
                       <FormattedMessage id="expenses.sendAnotherExpense" defaultMessage="Submit Another Expense" />
                     </Button>
-                    <Button className="whiteblue viewAllExpenses" href={`/${collective.slug}/expenses`}>
-                      <FormattedMessage id="expenses.viewAll" defaultMessage="View All Expenses" />
-                    </Button>
-                  </div>
-                </div>
+                    <Box ml={[null, null, 3]}>
+                      <Button className="whiteblue viewAllExpenses" href={`/${collective.slug}/expenses`}>
+                        <FormattedMessage id="expenses.viewAll" defaultMessage="View All Expenses" />
+                      </Button>
+                    </Box>
+                  </Flex>
+                </Box>
               }
 
               { showNewExpenseForm &&
@@ -143,24 +124,24 @@ class ExpensesPage extends React.Component {
                   collective={collective}
                   LoggedInUser={LoggedInUser}
                   onSubmit={this.createExpense}
-                  />
+                />
               }
 
-            </div>
+            </Box>
 
-            <div className="rightColumn">
+            <Box width={[1, null, 1/4]} pb={4} px={3}>
 
               <ExpensesStatsWithData slug={collective.slug} />
 
-              <div className="viewAllExpenses">
+              <Flex mt="5rem" justifyContent={['center', null, 'flex-start']}>
                 <Button href={`/${collective.slug}/expenses`}>
                   <FormattedMessage id="expenses.viewAll" defaultMessage="View All Expenses" />
                 </Button>
-              </div>
+              </Flex>
 
-            </div>
+            </Box>
 
-          </div>
+          </Flex>
 
         </Body>
 


### PR DESCRIPTION
The create expense page is not responsive as it currently keeps the expense stats component on the right side on smaller screens. 

This PR moves the expense stats components below the create expense form on smaller screens and refactors the spacing to be more consistent between the components. 


![screenshot_2018-07-26 brusselstogether - open collective](https://user-images.githubusercontent.com/3051193/43275718-92963b32-90d0-11e8-9217-c98e86d51c0a.png)
