### PR TITLE
Enable Collectives to pay other Collectives across different hosts

### DIFF
--- a/src/components/OrderForm.js
+++ b/src/components/OrderForm.js
@@ -237,7 +237,7 @@ class OrderForm extends React.Component {
 
     const filterPMs = (pms) => (pms || []).filter(pm =>
       ((pm.service === 'stripe' || pm.service === 'paypal') ||
-       (pm.service === 'opencollective' && pm.type === 'prepaid')));
+       (pm.service === 'opencollective' && (pm.type === 'prepaid' || pm.type === 'collective') )));
 
     if (collective) {
       const paymentMethods = filterPMs(collective.paymentMethods);
@@ -271,7 +271,7 @@ class OrderForm extends React.Component {
       fromCollectiveOptions.push({ [LoggedInUser.CollectiveId]: LoggedInUser.collective.name });
       collectivesById[LoggedInUser.CollectiveId] = LoggedInUser.collective;
       LoggedInUser.memberOf.map(membership => {
-        if (membership.collective.type === 'COLLECTIVE') return;
+        if (membership.collective.type === 'COLLECTIVE' && membership.role !== 'ADMIN') return;
         if (membership.collective.type === 'EVENT') return;
         if (membership.collective.type === 'ORGANIZATION' && !this.allowOrganizations) return;
         if (['ADMIN','HOST'].indexOf(membership.role) === -1) return;

--- a/src/components/OrderForm.js
+++ b/src/components/OrderForm.js
@@ -215,15 +215,17 @@ class OrderForm extends React.Component {
       const brand = get(pm, 'data.brand') || get(pm, 'type');
       /* The expiryDate field will show up for prepaid cards */
       const expiration = pm.expiryDate
-        ? moment(pm.expiryDate).format("MM/Y")
-        : `${get(pm, 'data.expMonth')}/${get(pm, 'data.expYear')}`;
+        ? `- exp ${moment(pm.expiryDate).format("MM/Y")}`
+        : (get(pm, 'data.expMonth') || get(pm, 'data.expYear'))
+            ? `- exp ${get(pm, 'data.expMonth')}/${get(pm, 'data.expYear')}`
+            : '';
       /* Prepaid cards have their balance available */
       const balance = pm.balance
         ? `(${formatCurrency(pm.balance, pm.currency)})`
         : '';
       /* Assemble all the pieces in one string */
       const name = `${brand} ${pm.name}`;
-      const label = `💳  \xA0\xA0${collective.name} - ${name} - exp ${expiration} ${balance}`;
+      const label = `💳  \xA0\xA0${collective.name} - ${name} ${expiration} ${balance}`;
       return { [value]: label };
     });
   }


### PR DESCRIPTION
Enable the `Contribute as` box to list collectives(that the logged in user is Admin) so it can make a payment through payments with the `opencollective` service and `collective` type.

1. `Contribute as` box: If user is admin of Collective, show it 
2. `Payment method`: If the service type is `opencollective` and type `collective`, show it as well.
3. fix text formatting regarding expiry date.

Closes opencollective/opencollective#1238