### PR TITLE
Fix validation issue on AddFundsForm

### DIFF
--- a/src/components/AddFundsForm.js
+++ b/src/components/AddFundsForm.js
@@ -74,7 +74,7 @@ class AddFundsForm extends React.Component {
         options: {
           collective: this.props.collective,
           host: this.props.host,
-          paymentMethod: get(this, 'props.host') ? this.props.host.paymentMethods.find(pm => pm.service === 'opencollective') : null,
+          paymentMethod: get(this, 'props.host.paymentMethods') ? this.props.host.paymentMethods.find(pm => pm.service === 'opencollective') : null,
         }
       },
       {

--- a/src/components/AddFundsForm.js
+++ b/src/components/AddFundsForm.js
@@ -74,7 +74,7 @@ class AddFundsForm extends React.Component {
         options: {
           collective: this.props.collective,
           host: this.props.host,
-          paymentMethod: this.props.host.paymentMethods.find(pm => pm.service === 'opencollective'),
+          paymentMethod: get(this, 'props.host') ? this.props.host.paymentMethods.find(pm => pm.service === 'opencollective') : null,
         }
       },
       {


### PR DESCRIPTION
Validating host property to avoid the following problem: 

![](https://user-images.githubusercontent.com/3671070/44734931-13a43380-aab9-11e8-89e9-855916ca63a9.png)

Closes opencollective/opencollective#1245